### PR TITLE
increase backwards-compatibility of C#-Bindings

### DIFF
--- a/csharp/IPConnection.cs
+++ b/csharp/IPConnection.cs
@@ -918,7 +918,12 @@ namespace Tinkerforge
 			}
 		}
 
-		public bool TryDequeue(out byte[] value, int timeout = Timeout.Infinite)
+		public bool TryDequeue(out byte[] value)
+		{
+			return TryDequeue(out value, Timeout.Infinite);
+		}
+		
+		public bool TryDequeue(out byte[] value, int timeout)
 		{
 			lock(queue)
 			{


### PR DESCRIPTION
Problem:
http://www.tinkerunity.org/forum/index.php/topic,294.0.html

Solution:
Don't use optional arguments, but overloaded methods instead.
