### PR TITLE
C#: Callback-methods should only be internally visible

### DIFF
--- a/csharp/generate_csharp_bindings.py
+++ b/csharp/generate_csharp_bindings.py
@@ -219,7 +219,7 @@ def make_register_callback():
 def make_callbacks():
     cbs = ''
     cb = """
-\t\tpublic int Callback{0}(byte[] data_)
+\t\tinternal int Callback{0}(byte[] data_)
 \t\t{{
 {1}\t\t\t(({0})callbacks[TYPE_{2}])({3});
 \t\t\treturn {4};


### PR DESCRIPTION
Hi,
while coding I noticed, that the Callback*-Methods on all Devices are public. Those are the methods called whenever the device should call its registered callbacks.
As those methods only serve internal purposes, they should not be callable from Binding-Clients.

This will btw. also improve usability of IDE autocompletion-features.
