### PR TITLE
C#: get_csharp_type should return array-extension

### DIFF
--- a/csharp/generate_csharp_bindings.py
+++ b/csharp/generate_csharp_bindings.py
@@ -80,13 +80,10 @@ def make_parameter_list(packet):
         if element[3] == 'out' and packet['type'] == 'method':
             out = 'out '
 
-        csharp_type = get_csharp_type(element[1])
+        csharp_type = get_csharp_type(element)
         name = to_camel_case(element[0])
-        arr = ''
-        if element[2] > 1 and element[1] != 'string':
-            arr = '[]'
        
-        param.append('{0}{1}{2} {3}'.format(out, csharp_type, arr, name))
+        param.append('{0}{1} {2}'.format(out, csharp_type, name))
     return ', '.join(param)
 
 def make_constructor():
@@ -139,7 +136,7 @@ def get_from_type(element):
     return ''
 
 
-def get_csharp_type(typ):
+def get_csharp_type(element):
     forms = {
         'int8' : 'sbyte',
         'uint8' : 'byte',
@@ -154,13 +151,18 @@ def get_csharp_type(typ):
         'string' : 'string',
         'char' : 'char'
     }
+    
+    sharpType = ''
+    if element[1] in forms:
+        sharpType = forms[element[1]]
+    else:
+        return ''
 
-    if typ in forms:
-        return forms[typ]
+    if element[2] > 1 and element[1] != 'string':
+        sharpType += '[]'
+    return sharpType
 
-    return ''
-
-
+	
 def get_type_size(element):
     forms = {
         'int8' : 1,
@@ -247,7 +249,7 @@ def make_callbacks():
             if element[3] != 'out':
                 continue
 
-            csharp_type = get_csharp_type(element[1])
+            csharp_type = get_csharp_type(element)
             cname = to_camel_case(element[0])
             from_type = get_from_type(element)
             length = ''


### PR DESCRIPTION
Hello,
while working on the c#-code-generator I noticed, that there is the method get_csharp_type, that returns me the csharp-type for a given config-type. However this method does not determine if the element this type belongs to is an array-element.

In make_parameter_list this behavior is added AFTER calling get_csharp_type, but in make_callbacks this behavior is not added. I believe that this is an error, as there should also be an array defined, if an array ist expected. The error was just not recognized because there are no Callbacks that accept an array.
## What does the Pull Request contain?
- the method get_csharp_type now expects an element instead of a type-string
- it returns the corresponding type including the array-extension ("[]")
- make_parameter_list got a bit simpler (logic moved to get_csharp_type)
- make_callbacks should now work as intended if there were array-parameters
