### PR TITLE
C#: Use StringBuilder in LEComverter.StringFrom(...)

### DIFF
--- a/csharp/IPConnection.cs
+++ b/csharp/IPConnection.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.IO;
+using System.Text;
 
 namespace Tinkerforge
 {
@@ -905,17 +906,17 @@ namespace Tinkerforge
 
 		static public string StringFrom(int position, byte[] array, int len) 
 		{
-			string s = "";
+			StringBuilder sb = new StringBuilder();
 			for(int i = position; i < position + len; i++) 
 			{
 				if(array[i] == 0)
 				{
 					break;
 				}
-				s += (char)array[i];
+				sb.Append((char)array[i]);
 			}
 
-			return s;
+			return sb.ToString();
 		}
 
 	}


### PR DESCRIPTION
For performance reasons it is advised to use a StringBuilder for situations where you append to a String very often.

The reason for this is, that String is immutable, thus if you append 5 times to a String, you will allocate a total of 6 Strings in memory (1x create first string + 5x create a new string for each append).

The stringbuilder puts far less pressure on GC and memory.
