### PR TITLE
Java: Building a device-name should respect NUL-Termination

### DIFF
--- a/java/IPConnection.java
+++ b/java/IPConnection.java
@@ -114,15 +114,19 @@ class CallbackThread extends Thread {
 				
 				String uid = ipcon.base58Encode(uid_num);
 				
-				String name = "";
+				StringBuilder nameBuilder = new StringBuilder();
 				for(int i = 0; i < 40; i++) {
-					name += (char)bb.get();
+					byte currentByte = bb.get();
+					if(currentByte == 0) {
+						break;
+					}
+					nameBuilder.append((char)currentByte);
 				}
 				
 				short stackID = ipcon.unsignedByte(bb.get());
 				boolean isNew = bb.get() != 0;
 				
-				ipcon.enumerateListener.enumerate(uid, name, stackID, isNew);
+				ipcon.enumerateListener.enumerate(uid, nameBuilder.toString(), stackID, isNew);
 			} else {
 				byte stackID = ipcon.getStackIDFromData(data);
 				Device device = ipcon.devices[stackID];


### PR DESCRIPTION
There is an open discussion in the forums, because the Java-Bindings don't shorten the device-name when the first NUL occurs.

This fix adds a NUL-check to the append-loop and also introduces the use of a StringBuilder instead of String-concatenation. The reason for the latter change is the same as in my C# Pull Request ("it is faster").

Commit was only compile-tested
