### PR TITLE
Java: add getters to commonly usable members of Device

### DIFF
--- a/java/Device.java
+++ b/java/Device.java
@@ -12,8 +12,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.SynchronousQueue;
 
 public abstract class Device {
-	long uid = (long)0;
-	short stackID = (short)0;
+	private long uid = 0L;
+	short stackID = 0;
 	String expectedName = null;
 	String name = null;
 	short[] firmwareVersion = new short[3];
@@ -65,5 +65,17 @@ public abstract class Device {
 		version.bindingVersion[2] = bindingVersion[2];
 
 		return version;
+	}
+	
+	public long getUid() {
+		return uid;
+	}
+
+	public short getStackID() {
+		return stackID;
+	}
+	
+	public String getName() {
+		return name;
 	}
 }

--- a/java/IPConnection.java
+++ b/java/IPConnection.java
@@ -326,7 +326,7 @@ public class IPConnection {
 		bb.order(ByteOrder.LITTLE_ENDIAN);
 
 		long uid = bb.getLong();
-		if(pendingAddDevice.uid == uid) {
+		if(pendingAddDevice.getUid() == uid) {
 			pendingAddDevice.firmwareVersion[0] = unsignedByte(bb.get());
 			pendingAddDevice.firmwareVersion[1] = unsignedByte(bb.get());
 			pendingAddDevice.firmwareVersion[2] = unsignedByte(bb.get());
@@ -339,7 +339,7 @@ public class IPConnection {
 
 			pendingAddDevice.name = name;
 			pendingAddDevice.stackID = unsignedByte(bb.get());
-			devices[pendingAddDevice.stackID] = pendingAddDevice;
+			devices[pendingAddDevice.getStackID()] = pendingAddDevice;
 			try {
 				pendingAddDevice.responseQueue.put(packet);
 			} catch(InterruptedException e) {
@@ -461,7 +461,7 @@ public class IPConnection {
 	 */
 	public void addDevice(Device device) throws TimeoutException {
 		ByteBuffer request = createRequestBuffer(BROADCAST_ADDRESS, FUNCTION_GET_STACK_ID, (short)12);
-		request.putLong(device.uid);
+		request.putLong(device.getUid());
 
 		synchronized(addDeviceMutex) {
 			pendingAddDevice = device;
@@ -478,7 +478,7 @@ public class IPConnection {
 				try {
 					response = pendingAddDevice.responseQueue.poll(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
 					if(response == null) {
-						throw new TimeoutException("Could not add device " + base58Encode(device.uid) + ", timeout");
+						throw new TimeoutException("Could not add device " + base58Encode(device.getUid()) + ", timeout");
 					}
 				} catch (InterruptedException e) {
 					e.printStackTrace();


### PR DESCRIPTION
Added some getters to members like UID, name and stack-id.
Also changed reading access to those fields from outside the Device-class to use the getters instead of the members.

It could be discussed to also change writing to use some package-visible setters as this would reflect typical java-conventions (access all members via getters and setters).
