### PR TITLE
C#: improve locking

### DIFF
--- a/csharp/IPConnection.cs
+++ b/csharp/IPConnection.cs
@@ -964,17 +964,19 @@ namespace Tinkerforge
 				expectedResponseFunctionID = functionID;
 				expectedResponseSequenceNumber = (byte)((request[6] >> 4) & 0xF);
 
-				ipcon.Write(request);
-
-				if (!responseQueue.TryDequeue(out response, ipcon.responseTimeout))
-				{
-					expectedResponseFunctionID = 0;
-					expectedResponseSequenceNumber = 0;
-					throw new TimeoutException("Did not receive response in time");
-				}
-
-				expectedResponseFunctionID = 0;
-				expectedResponseSequenceNumber = 0;
+                try
+                {
+                    ipcon.Write(request);
+                    if (!responseQueue.TryDequeue(out response, ipcon.responseTimeout))
+                    {
+                        throw new TimeoutException("Did not receive response in time");
+                    }
+                }
+                finally
+                {
+                    expectedResponseFunctionID = 0;
+                    expectedResponseSequenceNumber = 0;
+                }
 
 				byte errorCode = IPConnection.GetErrorCodeFromData(response);
 				switch(errorCode)


### PR DESCRIPTION
This Pull Request is smaller than I thought, but still worth sharing :)

After a long time I finally took a look at the new locking.
Here are my findings:
The method IPConnection.Write() was always called in the same way:
1. aquire the socketLock
2. check if the IPConnections socket is connected, if not throw an exception
3. call IPConnection.Write()

For this reason I included steps one and two in the Write-method, as the socketLock was only neccessary to make the socket-check and the socket-use atomic.
This yielded two benefits:
1. The Device did those checks on IPConnection before which was an encapsulation break, so the Device-code became cleaner and more understandable
2. It was now possible to get rid of the socketWriterLock, as its purpose was now fully fulfilled by the socketLock.

Hope you like to pull this, even if it does not fix any bugs, but only makes code more readable and maintainable (and a tiny tiny little bit faster ^^)
