### PR TITLE
C#: shorten internal representation of UIDs to 32 Bit

### DIFF
--- a/csharp/IPConnection.cs
+++ b/csharp/IPConnection.cs
@@ -641,7 +641,7 @@ namespace Tinkerforge
 
 		internal static int GetUIDFromData(byte[] data)
 		{
-			return (int)(((int)data[0]) & 0xFF) | (int)((((int)data[1]) & 0xFF) << 8) | (int)((((int)data[2]) & 0xFF) << 16) | (int)((((int)data[3]) & 0xFF) << 24);
+			return LEConverter.IntFrom(0, data);
 		}
 
 		private static byte GetSequenceNumberFromData(byte[] data) {


### PR DESCRIPTION
While working on another project inside your code (where I don't know if I will ever make a Pull Request) I realized that your internal representation of UIDs is still 64 Bit while the new protocol only knows about 32 Bit.

This Pull Request shortens the internal representation down to 32 Bit. I made a quick test with small and UIDs and it still seems to work, however... you might want to make sure I didn't break anything.
## Trivia

In MakePacketHeader, if you would swap the assignment-order of uid and length (i.e. set length first), the UID would currently overwrite the length field (this is how I noticed that UIDs are too long internally ^^)
