### PR TITLE
Python: avoid orphan threads on connection failure

### DIFF
--- a/python/ip_connection.py
+++ b/python/ip_connection.py
@@ -483,6 +483,7 @@ class IPConnection:
         except:
             # FIXME: cleanup
             self.socket = None
+            callback.queue.put((IPConnection.QUEUE_EXIT, None))
             raise
 
         # create disconnect probe thread


### PR DESCRIPTION
On connecting to a brick a callback processor (callback_loop) is called. When the connection failed, an exception is raised, without stopping the callback thread. This increases the thread count for each connection retry.
Calling "disconnect" won't shut the thread down, because the socket is not connected.

Sending an QUEUE_EXIT to the callback queue when the connection fails, will make the callback_loop exit.

I am not sure if this affects the "is_auto_reconnect" handling.
