### PR TITLE
Added OSGi compatibility, and updated maven plugins versions.

### DIFF
--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tinkerforge</groupId>
   <artifactId>tinkerforge</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>{{VERSION}}</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -44,6 +44,12 @@
           <target>1.5</target>
           <encoding>UTF-8</encoding>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.0</version>
+        <extensions>true</extensions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.3</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>2.4</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -67,7 +67,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -80,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.5</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>


### PR DESCRIPTION
Hey Guys,

For our work over at https://github.com/camel-labs/camel-labs it would be very nice if you could add OSGi compatibility. This pull request contains the change to add that. Its very simple, just adds the Bnd plugin which is the standard way in the Java world to create OSGi headers for a Jar file.
It also updates the maven plugin versions to the latest and greatest, as a free bonus :)

Let me know what you think.

Kind regards,
your neighbor from the Netherlands,
Geert Schuring.