### PR TITLE
Use recommended order of Java modifiers

### DIFF
--- a/java/generate_java_bindings.py
+++ b/java/generate_java_bindings.py
@@ -102,8 +102,8 @@ import java.util.List;
  * {1}
  */
 public class {0} extends Device {{
-	public final static int DEVICE_IDENTIFIER = {2};
-	public final static String DEVICE_DISPLAY_NAME = "{3}";
+	public static final int DEVICE_IDENTIFIER = {2};
+	public static final String DEVICE_DISPLAY_NAME = "{3}";
 
 """
 
@@ -689,8 +689,8 @@ public class {0} extends Device {{
 
     def get_java_function_id_definitions(self):
         function_ids = ''
-        template_function = '\tpublic final static byte FUNCTION_{0} = (byte){1};\n'
-        template_callback = '\tprivate final static int CALLBACK_{0} = {1};\n'
+        template_function = '\tpublic static final byte FUNCTION_{0} = (byte){1};\n'
+        template_callback = '\tprivate static final int CALLBACK_{0} = {1};\n'
 
         for packet in self.get_packets('function'):
             function_ids += template_function.format(packet.get_name().upper,
@@ -708,7 +708,7 @@ public class {0} extends Device {{
         return function_ids
 
     def get_java_constants(self):
-        template = '\tpublic final static {0} {1}_{2} = {3}{4};\n'
+        template = '\tpublic static final {0} {1}_{2} = {3}{4};\n'
         constants = []
 
         for constant_group in self.get_constant_groups():


### PR DESCRIPTION
This pull request changes the order of the Java modifiers in the generated binding classes as recommended for Java code.

See also:

  - [Class Modifiers section in Java 8 Specs](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.1.1)
  - [Field Modifiers section in Java 8 Specs](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.1)
  - [Method Modifiers section in Java 8 Specs](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.3)
  - [SonarSource code analysis rule RSPEC-1124](https://rules.sonarsource.com/java/tag/convention/RSPEC-1124)

Note: I have linked to the Java 8 specification because the minimum requirement for the Tinkerforge Java bindings is Java 8.