### PR TITLE
#65 Fix mapping of char from rune to byte

### DIFF
--- a/go/byteconverter.go
+++ b/go/byteconverter.go
@@ -161,27 +161,13 @@ func ByteSliceToFloat64Slice(slice []byte) []float64 {
 	return result
 }
 
-func ByteSliceToRuneSlice(slice []byte) []rune {
-	result := make([]rune, len(slice))
-	for idx, b := range slice {
-		result[idx] = rune(b)
-	}
-	return result
-}
-
-func RuneSliceToByteSlice(slice []rune) []byte {
-	result := make([]byte, len(slice))
-	for idx, b := range slice {
-		result[idx] = byte(b)
-	}
-	return result
-}
 
 func ByteSliceToString(slice []byte) string {
 	n := bytes.IndexByte(slice, 0)
 	return string(slice[:n])
 }
 
+// Todo: This would break encoding of UTF-8 chars. Evaluate []byte(str)
 func StringToByteSlice(str string, maxLen uint64) ([]byte, error) {
 	runes := []rune(str)
 	bytes := make([]byte, maxLen, maxLen)

--- a/go/changelog.txt
+++ b/go/changelog.txt
@@ -103,5 +103,5 @@
 2025-10-07: 2.0.17 (9ad863d)
 - Fix bool arrays in setters
 
-2026-04-15: 2.0.18 (<unknown>)
+2026-04-15: 2.0.18 (7685cab7)
 - Fix mapping of char from rune to byte (Issue: https://github.com/Tinkerforge/generators/issues/65)

--- a/go/changelog.txt
+++ b/go/changelog.txt
@@ -102,3 +102,6 @@
 
 2025-10-07: 2.0.17 (9ad863d)
 - Fix bool arrays in setters
+
+2026-04-15: 2.0.18 (<unknown>)
+- Fix mapping of char from rune to byte (Issue: https://github.com/Tinkerforge/generators/issues/65)

--- a/go/example_authenticate.go
+++ b/go/example_authenticate.go
@@ -34,7 +34,7 @@ func main() {
 		ipcon.Enumerate()            // then trigger enumerate.
 	})
 
-	ipcon.RegisterEnumerateCallback(func(uid string, connectedUid string, position rune, hardwareVersion [3]uint8,
+	ipcon.RegisterEnumerateCallback(func(uid string, connectedUid string, position byte, hardwareVersion [3]uint8,
 	                                     firmwareVersion [3]uint8, deviceIdentifier uint16, enumerationType ipconnection.EnumerationType) {
 		fmt.Printf("UID:               %s\n", uid)
 		switch enumerationType {

--- a/go/example_enumerate.go
+++ b/go/example_enumerate.go
@@ -15,7 +15,7 @@ func main() {
 	defer ipcon.Disconnect()
 	// Don't use device before ipcon is connected.
 
-	ipcon.RegisterEnumerateCallback(func(uid string, connectedUid string, position rune, hardwareVersion [3]uint8,
+	ipcon.RegisterEnumerateCallback(func(uid string, connectedUid string, position byte, hardwareVersion [3]uint8,
 	                                     firmwareVersion [3]uint8, deviceIdentifier uint16, enumerationType ipconnection.EnumerationType) {
 		fmt.Printf("UID:               %s\n", uid)
 		switch enumerationType {

--- a/go/generate_go_bindings.py
+++ b/go/generate_go_bindings.py
@@ -123,7 +123,7 @@ const (
             enum_values = []
 
             for constant in constant_group.get_constants():
-                value = str(constant.get_value()) if not "rune" in constant_type else "'" + constant.get_value() + "'"
+                value = str(constant.get_value()) if not "byte" in constant_type else "'" + constant.get_value() + "'"
 
                 if constant_type == "bool":
                     value = value.lower()
@@ -187,16 +187,14 @@ const (
     def go_read_results(self, elements, bufferName, low_level_in_bits=True):
         read_results = []
         for elem in elements:
-            size = elem.get_size()
-
             if elem.get_level() == 'low' and elem.get_role() == 'stream_chunk_data':
                 read_results.append("copy({name}[:], ByteSliceTo{type}Slice({buf}.Next({mult} * {chunk_size}/8)))".format(buf=bufferName, name=elem.get_go_name(), type=elem.get_go_type(ignore_cardinality=True).title(), chunk_size= elem.get_cardinality(), mult =  go_common.get_go_type_size(elem.get_go_type(ignore_cardinality=True))))
                 continue
 
-            if "rune" in elem.get_go_type() and elem.get_cardinality() == 1:
-                read_results.append("{ret_name} = rune({buf}.Next(1)[0])".format(buf=bufferName, ret_name=elem.get_go_name()))
-            elif "rune" in elem.get_go_type():
-                read_results.append("copy({ret_name}[:], ByteSliceTo{type}Slice({buf}.Next({len})))".format(buf=bufferName, ret_name=elem.get_go_name(), type=elem.get_go_type(ignore_cardinality=True).title(), len=elem.get_cardinality()))
+            if "byte" in elem.get_go_type() and elem.get_cardinality() == 1:
+                read_results.append("{ret_name} = {buf}.Next(1)[0]".format(buf=bufferName, ret_name=elem.get_go_name()))
+            elif "byte" in elem.get_go_type():
+                read_results.append("copy({ret_name}[:], {buf}.Next({len}))".format(buf=bufferName, ret_name=elem.get_go_name(), type=elem.get_go_type(ignore_cardinality=True).title(), len=elem.get_cardinality()))
             elif "bool" in elem.get_go_type() and elem.get_cardinality() > 1:
                 read_results.append("copy({ret_name}[:], ByteSliceTo{type}Slice({buf}.Next({len})))".format(buf=bufferName, ret_name=elem.get_go_name(), type=elem.get_go_type(ignore_cardinality=True).title(), len=math.ceil(elem.get_cardinality() / 8)))
             elif elem.get_go_type() == "string":

--- a/go/go_common.py
+++ b/go/go_common.py
@@ -246,7 +246,7 @@ class GoElement(common.Element):
             return self.get_constant_group(index=self.get_indices()[0]).get_name().camel
 
         if self.get_type() == 'char':
-            element_type = 'rune'
+            element_type = 'byte'
         elif self.get_type() == 'string':
             return 'string'
         elif self.get_type() == 'bool':
@@ -281,7 +281,7 @@ go_types = {
     'uint64': 'uint64',
     'float':  'float32',
     'bool':   'bool',
-    'char':   'rune',
+    'char':   'byte',
     'string': 'string'
 }
 
@@ -296,7 +296,7 @@ go_sizes = {
     'uint64': 64,
     'float32':32,
     'bool':   1,
-    'rune':   8,
+    'byte':   8,
     'string': 'string'
 }
 

--- a/go/ipcon_handle.go
+++ b/go/ipcon_handle.go
@@ -75,7 +75,7 @@ func (ipcon *IPConnection) RegisterDisconnectCallback(fn func(DisconnectReason))
 //     For the bottommost Brick in a stack it is "0".
 //     With this information it is possible to reconstruct the complete network topology.
 //
-// * position rune -  For Bricks: '0' - '8' (position in stack). For Bricklets: 'a' - 'd' (position on Brick).
+// * position byte -  For Bricks: '0' - '8' (position in stack). For Bricklets: 'a' - 'd' (position on Brick).
 //
 // * hardwareVersion [3]uint8 - Major, minor and release number for hardware version.
 //
@@ -88,7 +88,7 @@ func (ipcon *IPConnection) RegisterDisconnectCallback(fn func(DisconnectReason))
 //     For example: master_brick.DeviceIdentifier or ambient_light_bricklet.DeviceIdentifier.
 //
 // * enumerationType EnumerationType - Type of enumeration.
-func (ipcon *IPConnection) RegisterEnumerateCallback(fn func(uid string, connectedUID string, position rune, hardwareVersion [3]uint8, firmwareVersion [3]uint8, deviceIdentifier uint16, enumerationType EnumerationType)) uint64 {
+func (ipcon *IPConnection) RegisterEnumerateCallback(fn func(uid string, connectedUID string, position byte, hardwareVersion [3]uint8, firmwareVersion [3]uint8, deviceIdentifier uint16, enumerationType EnumerationType)) uint64 {
 	wrapper := func(bytes []byte) {
 		var header internal.PacketHeader
 
@@ -100,7 +100,7 @@ func (ipcon *IPConnection) RegisterEnumerateCallback(fn func(uid string, connect
 		bytes = bytes[8:]
 		uid := internal.ByteSliceToString(bytes[0:8])
 		connectedUID := internal.ByteSliceToString(bytes[8:16])
-		position := rune(bytes[16])
+		position := bytes[16] // Todo: Evaluate a custom datatype with .String() etc.
 		hardwareVersion := [3]uint8{bytes[17], bytes[18], bytes[19]}
 		firmwareVersion := [3]uint8{bytes[20], bytes[21], bytes[22]}
 		deviceIdentifier := binary.LittleEndian.Uint16(bytes[23:25])


### PR DESCRIPTION
This pull request fixes #65 by correcting incorrect mappings from rune to byte.

This is a breaking change, but the assigned version does not reflect that. Since I am not familiar with the Tinkerforge versioning policy, only the bugfix version has been incremented.

Additionally, the types and APIs could be further refactored to be more idomatic (e.g. implementation of io.Reader/Writer, ...).